### PR TITLE
Fix identifiers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>infolis</groupId>
     <artifactId>metaDataTransformer</artifactId>
-    <version>1.2-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>infolis</groupId>
     <artifactId>metaDataTransformer</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>infolis</groupId>
     <artifactId>metaDataTransformer</artifactId>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <build>
         <plugins>

--- a/src/main/java/infolis/metaDataTransformer/icpsr/ICPSRTransformer.java
+++ b/src/main/java/infolis/metaDataTransformer/icpsr/ICPSRTransformer.java
@@ -8,6 +8,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.util.Arrays;
+import java.util.List;
+import java.util.ArrayList;
 
 /**
  *
@@ -30,8 +32,12 @@ public class ICPSRTransformer {
                 Publication p = gson.fromJson(read, Publication.class);
 
                 String title = p.getMetadata().getZotero()[0].getTitle();
-                String identifier = p.getDoi();
+                String recordIdentifier = null;
+                // TODO other identifiers?
+                List<String> identifiers = new ArrayList<>();
+                identifiers.add(p.getDoi());
                 String url = p.getUrl();
+                identifiers.add(url);
                 String abstractDesc = p.getMetadata().getZotero()[0].getAbstractNote();
                 String language = p.getMetadata().getZotero()[0].getLanguage();
                 Creator[] authors = p.getMetadata().getZotero()[0].getCreators();
@@ -44,7 +50,7 @@ public class ICPSRTransformer {
                     subjects = p.getMetadata().getCrossRefWorks().getSubject();
                 }
 
-                OutputWriter write = new OutputWriter(language, abstractDesc, title, identifier, url, Arrays.asList(authorsStrings), Arrays.asList(subjects), outputPath, f.getName());
+                OutputWriter write = new OutputWriter(language, abstractDesc, title, recordIdentifier, identifiers, Arrays.asList(authorsStrings), Arrays.asList(subjects), outputPath, f.getName());
                 write.writeOutput();
             } catch (Exception e) {
                 System.out.println(f.getName());

--- a/src/main/java/infolis/metaDataTransformer/output/OutputWriter.java
+++ b/src/main/java/infolis/metaDataTransformer/output/OutputWriter.java
@@ -21,15 +21,15 @@ import org.w3c.dom.Element;
  */
 public class OutputWriter {
 
-    String lang = null, abstractDesc = null, title = null, identifier = null, uri = null;
-    List<String> authors = new ArrayList<>(), subjects = new ArrayList<>(), identifiers = new ArrayList<>();
+    String lang = null, abstractDesc = null, title = null, recordIdentifier = null, uri = null;
+    List<String> authors = new ArrayList<>(), subjects = new ArrayList<>(), datasetIdentifiers = new ArrayList<>();
     String outputPath = null, fileName = null;
     
-    public OutputWriter(String lang, String abstractDesc, String title, String identifier, String uri, List<String> authors, List<String> subjects, String outputPath, String fileName) {
+    public OutputWriter(String lang, String abstractDesc, String title, String recordIdentifier, String uri, List<String> authors, List<String> subjects, String outputPath, String fileName) {
         this.lang = lang;
         this.abstractDesc = abstractDesc;
         this.title = title;
-        this.identifier = identifier;
+        this.recordIdentifier = recordIdentifier;
         this.uri = uri;
         this.authors = authors;
         this.subjects = subjects;
@@ -37,11 +37,13 @@ public class OutputWriter {
         this.fileName = fileName;
     }
     
-    public OutputWriter(String lang, String abstractDesc, String title, List<String> identifiers, List<String> authors, List<String> subjects, String outputPath, String fileName) {
+    public OutputWriter(String lang, String abstractDesc, String title, String recordIdentifier, 
+    List<String> datasetIdentifiers, List<String> authors, List<String> subjects, String outputPath, String fileName) {
         this.lang = lang;
         this.abstractDesc = abstractDesc;
         this.title = title;
-        this.identifiers = identifiers;
+        this.recordIdentifier = recordIdentifier;
+        this.datasetIdentifiers = datasetIdentifiers;
         this.authors = authors;
         this.subjects = subjects;
         this.outputPath = outputPath;
@@ -61,9 +63,9 @@ public class OutputWriter {
             node.appendChild(header);
 
             // append child elements to root element
-            if (null != identifier) {
+            if (null != recordIdentifier) {
                 Element identifierEle = docOut.createElement("identifier");
-                identifierEle.setTextContent(identifier);
+                identifierEle.setTextContent(recordIdentifier);
                 header.appendChild(identifierEle);
             }
 
@@ -91,7 +93,7 @@ public class OutputWriter {
                 ns1.appendChild(uriEle);
             }
             
-            for (String id : identifiers) {
+            for (String id : datasetIdentifiers) {
                 Element idEle = docOut.createElement("dc:identifier");
                 idEle.setTextContent(id);
                 ns1.appendChild(idEle);

--- a/src/main/java/infolis/metaDataTransformer/output/OutputWriter.java
+++ b/src/main/java/infolis/metaDataTransformer/output/OutputWriter.java
@@ -22,7 +22,7 @@ import org.w3c.dom.Element;
 public class OutputWriter {
 
     String lang = null, abstractDesc = null, title = null, identifier = null, uri = null;
-    List<String> authors = new ArrayList<>(), subjects = new ArrayList<>();
+    List<String> authors = new ArrayList<>(), subjects = new ArrayList<>(), identifiers = new ArrayList<>();
     String outputPath = null, fileName = null;
     
     public OutputWriter(String lang, String abstractDesc, String title, String identifier, String uri, List<String> authors, List<String> subjects, String outputPath, String fileName) {
@@ -31,6 +31,17 @@ public class OutputWriter {
         this.title = title;
         this.identifier = identifier;
         this.uri = uri;
+        this.authors = authors;
+        this.subjects = subjects;
+        this.outputPath = outputPath;
+        this.fileName = fileName;
+    }
+    
+    public OutputWriter(String lang, String abstractDesc, String title, List<String> identifiers, List<String> authors, List<String> subjects, String outputPath, String fileName) {
+        this.lang = lang;
+        this.abstractDesc = abstractDesc;
+        this.title = title;
+        this.identifiers = identifiers;
         this.authors = authors;
         this.subjects = subjects;
         this.outputPath = outputPath;
@@ -50,9 +61,11 @@ public class OutputWriter {
             node.appendChild(header);
 
             // append child elements to root element
-            Element identifierEle = docOut.createElement("identifier");
-            identifierEle.setTextContent(identifier);
-            header.appendChild(identifierEle);
+            if (null != identifier) {
+                Element identifierEle = docOut.createElement("identifier");
+                identifierEle.setTextContent(identifier);
+                header.appendChild(identifierEle);
+            }
 
             Element metadata = docOut.createElement("metadata");
             node.appendChild(metadata);
@@ -72,9 +85,17 @@ public class OutputWriter {
             langEle.setTextContent(lang);
             ns1.appendChild(langEle);
 
-            Element uriEle = docOut.createElement("dc:identifier");
-            uriEle.setTextContent(uri);
-            ns1.appendChild(uriEle);
+            if (null != uri) {
+                Element uriEle = docOut.createElement("dc:identifier");
+                uriEle.setTextContent(uri);
+                ns1.appendChild(uriEle);
+            }
+            
+            for (String id : identifiers) {
+                Element idEle = docOut.createElement("dc:identifier");
+                idEle.setTextContent(id);
+                ns1.appendChild(idEle);
+            }
 
             Element absEle = docOut.createElement("dc:description");
             absEle.setTextContent(abstractDesc);

--- a/src/main/java/infolis/metaDataTransformer/ssoar/SSOARTransformator.java
+++ b/src/main/java/infolis/metaDataTransformer/ssoar/SSOARTransformator.java
@@ -36,9 +36,9 @@ public class SSOARTransformator {
         File inDir = new File(inputPath);
         for (File f : inDir.listFiles()) {
 
-            String lang = null, abstractDesc = null, title = null;
+            String lang = null, abstractDesc = null, title = null, recordIdentifier = null;
             List<String> authors = new ArrayList<>(), subjects = new ArrayList<>(), 
-            identifiers = new ArrayList<>();
+            datasetIdentifiers = new ArrayList<>();
 
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             DocumentBuilder db = dbf.newDocumentBuilder();
@@ -47,7 +47,7 @@ public class SSOARTransformator {
             NodeList fieldNodesHeader = doc.getElementsByTagName("ns0:identifier");
             for (int j = 0; j < fieldNodesHeader.getLength(); j++) {
                 Node fieldNode = fieldNodesHeader.item(j);
-                identifiers.add(fieldNode.getTextContent());
+                recordIdentifier = fieldNode.getTextContent();
             }
 
             NodeList fieldNodesBegin = doc.getElementsByTagName("ns1:dcvalue");
@@ -87,12 +87,12 @@ public class SSOARTransformator {
                         title = fieldNode.getTextContent();
                     }
                     if (element.getTextContent().equals("identifier")) {
-                        identifiers.add(fieldNode.getTextContent());
+                        datasetIdentifiers.add(fieldNode.getTextContent());
                     }
                 }
             }
            
-            OutputWriter writer = new OutputWriter(lang, abstractDesc, title, identifiers, authors, subjects, outputPath, f.getName());
+            OutputWriter writer = new OutputWriter(lang, abstractDesc, title, recordIdentifier, datasetIdentifiers, authors, subjects, outputPath, f.getName());
             writer.writeOutput();
             
         }

--- a/src/main/java/infolis/metaDataTransformer/ssoar/SSOARTransformator.java
+++ b/src/main/java/infolis/metaDataTransformer/ssoar/SSOARTransformator.java
@@ -36,8 +36,9 @@ public class SSOARTransformator {
         File inDir = new File(inputPath);
         for (File f : inDir.listFiles()) {
 
-            String lang = null, abstractDesc = null, title = null, identifier = null, uri = null;
-            List<String> authors = new ArrayList<>(), subjects = new ArrayList<>();
+            String lang = null, abstractDesc = null, title = null;
+            List<String> authors = new ArrayList<>(), subjects = new ArrayList<>(), 
+            identifiers = new ArrayList<>();
 
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
             DocumentBuilder db = dbf.newDocumentBuilder();
@@ -46,7 +47,7 @@ public class SSOARTransformator {
             NodeList fieldNodesHeader = doc.getElementsByTagName("ns0:identifier");
             for (int j = 0; j < fieldNodesHeader.getLength(); j++) {
                 Node fieldNode = fieldNodesHeader.item(j);
-                identifier = fieldNode.getTextContent();
+                identifiers.add(fieldNode.getTextContent());
             }
 
             NodeList fieldNodesBegin = doc.getElementsByTagName("ns1:dcvalue");
@@ -85,13 +86,13 @@ public class SSOARTransformator {
                     if (element.getTextContent().equals("title") && language != null && language.getTextContent().equals(lang) && qualifier ==null) {
                         title = fieldNode.getTextContent();
                     }
-                    if (element.getTextContent().equals("identifier") && qualifier != null && qualifier.getTextContent().equals("uri")) {
-                        uri = fieldNode.getTextContent();
+                    if (element.getTextContent().equals("identifier")) {
+                        identifiers.add(fieldNode.getTextContent());
                     }
                 }
             }
            
-            OutputWriter writer = new OutputWriter(lang, abstractDesc, title, identifier, uri, authors, subjects, outputPath, f.getName());
+            OutputWriter writer = new OutputWriter(lang, abstractDesc, title, identifiers, authors, subjects, outputPath, f.getName());
             writer.writeOutput();
             
         }


### PR DESCRIPTION
preserve identifiers for ssoar and icpsr.

Please check whether
1) all identifiers are preserved for the other meta data formats. If not, please adjust.
2) keeping the "uri" class variable is necessary
